### PR TITLE
Alternative QVector data access added

### DIFF
--- a/MyTableItem.cpp
+++ b/MyTableItem.cpp
@@ -9,7 +9,7 @@ QVariant MyTableItem::data(int column, int role) const
 {
     Q_ASSERT(column >= 0 && column < columnCount() );
 
-    return mColumns[column][role];
+    return _columns.at(column)[role];
 }
 
 void MyTableItem::setData(int column, const QVariant& value, int role)


### PR DESCRIPTION
Qt Doc :
[`at()`](http://doc.qt.io/qt-5/qvector.html#at) can be faster than operator[], because it never causes a [`deep copy`](http://doc.qt.io/qt-5/implicit-sharing.html#deep-copy) to occur.
